### PR TITLE
replace ccall with stdcall

### DIFF
--- a/src/System/Signal.hs
+++ b/src/System/Signal.hs
@@ -42,10 +42,10 @@ type Handler = Signal -> IO ()
 
 installHandler :: Signal -> Handler -> IO ()
 #ifdef mingw32_HOST_OS
-foreign import ccall "wrapper"
+foreign import stdcall "wrapper"
     genHandler:: Handler -> IO (FunPtr Handler)
 
-foreign import ccall safe "signal.h signal"
+foreign import stdcall safe "signal.h signal"
     install:: Signal -> FunPtr Handler -> IO Signal
 
 installHandler signal handler = do


### PR DESCRIPTION
- Resolves linker issues on msys2/ucrt64
- the signal function could not be found